### PR TITLE
fix: switch colors for disabled inputs

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -659,7 +659,17 @@ https://getbootstrap.com/docs/5.3/examples/
       <div class="px-3 py-2 border-bottom mb-3">
         <div class="container d-flex flex-wrap justify-content-center">
           <form class="col-12 col-lg-auto mb-2 mb-lg-0 me-lg-auto" role="search">
-            <input type="search" class="form-control" placeholder="Search..." aria-label="Search">
+            <input type="search" class="form-control mb-1" placeholder="Search..." aria-label="Search">
+            <input type="text" class="form-control mb-1" placeholder="">
+            <input type="text" disabled class="form-control mb-1" value="Disabled Text">
+            <select class="form-select mb-1">
+              <option>Option 1</option>
+              <option>Option 2</option>
+            </select>
+            <select class="form-select mb-1" disabled>
+              <option>Option 1</option>
+              <option>Option 2</option>
+            </select>
           </form>
 
           <div class="text-end">

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -46,6 +46,13 @@ $body-tertiary-bg-dark: $gk-surface-dark;
 $body-color: $gk-fg-light;
 $body-color-dark: $gk-fg-dark;
 
+$input-bg: var(--bs-secondary-bg);
+$input-disabled-bg: var(--bs-body-bg);
+$input-disabled-color: var(--bs-tertiary-color);
+
+$form-select-disabled-color: $input-disabled-color;
+$form-select-disabled-bg: $input-disabled-bg;
+
 $min-contrast-ratio: 2;
 
 $font-family-base: $font-family-main;


### PR DESCRIPTION
A discussable attempt to make disabled inputs more obvious. Recently it seems that the colors had been switched (it looked like input is possible when it was disabled, and vice versa). 

The problem is that it looks quite good for dark mode, but a bit too "muted" for light mode right now. The alternative is too make it look quite good for light mode, but then it looks not disabled enough in dark mode.

With this PR (tertiary color for disabled inputs), it looks like this:

![Screenshot from 2024-09-19 15-01-48](https://github.com/user-attachments/assets/5e6b11f0-928a-4de3-817f-f81a1b4033e0)

![Screenshot from 2024-09-19 15-02-05](https://github.com/user-attachments/assets/1233cdce-54bd-4bf7-b542-16aa6fe3ee1f)

Alternative (secondary color for disabled inputs):

![Screenshot from 2024-09-19 15-03-12](https://github.com/user-attachments/assets/0c12bb10-bcd7-43d8-8d49-cce549662fca)

![Screenshot from 2024-09-19 15-03-27](https://github.com/user-attachments/assets/83b818e4-415b-41a2-8fb1-c9555db6e4e7)

Ref https://github.com/glasskube/glasskube/issues/1167